### PR TITLE
fixing not found resource for java play libraries

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -38,7 +38,8 @@ download_play_official() {
   local playVersion=${1}
   local playTarFile=${2}
   local playZipFile="play-${playVersion}.zip"
-  local playUrl="https://downloads.typesafe.com/play/${playVersion}/${playZipFile}"
+  local playUrl="https://repo1.maven.org/maven2/com/google/code/maven-play-plugin/org/playframework/play/${playVersion}/play-${playVersion}-framework.zip"
+  # local playUrl="https://downloads.typesafe.com/play/${playVersion}/${playZipFile}"
   
   if [[ "$playVersion" > "1.6.0" ]]; then
     playUrl="https://github.com/playframework/play1/releases/download/${playVersion}/${playZipFile}"


### PR DESCRIPTION
## Summary by Sourcery

Updates the download URL for Play framework to resolve resource not found errors.

Bug Fixes:
- Fixes an issue where the Play framework zip file could not be downloaded from the original source.

Build:
- Updates the download URL for Play framework zip files to use a Maven repository as the original download location is no longer available.